### PR TITLE
Remove unnecessary FunctionalDependency

### DIFF
--- a/src/Network/KRPC/Method.hs
+++ b/src/Network/KRPC/Method.hs
@@ -9,7 +9,6 @@
 --
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE DefaultSignatures          #-}
@@ -75,7 +74,7 @@ showsMethod (Method name) =
 --   @
 --
 class (Typeable req, BEncode req, Typeable resp, BEncode resp)
-    => KRPC req resp | req -> resp where
+    => KRPC req resp where
 
   -- | Method name. Default implementation uses lowercased @req@
   -- datatype name.


### PR DESCRIPTION
This fixes cobit/bittorrent#7 for GHC 7.8.3: 7.8.3 fixed
FunctionalDependencies so the existing instances are no longer allowed
and in fact FD is not necessary there at all.
